### PR TITLE
chore: update forgejo helm repo URL

### DIFF
--- a/kubernetes/cluster-1/system/repos/forgejo.yaml
+++ b/kubernetes/cluster-1/system/repos/forgejo.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: oci://codeberg.org/forgejo-contrib
+  url: oci://code.forgejo.org/forgejo-helm
   type: oci


### PR DESCRIPTION
Migrated to `code.forgejo.org`: <https://code.forgejo.org/forgejo-helm/forgejo-helm#installing>