### PR TITLE
feat: enable Toolhive code mode and pin versions

### DIFF
--- a/kubernetes/cluster-1/toolhive/crds.yaml
+++ b/kubernetes/cluster-1/toolhive/crds.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: toolhive-operator-crds
+      version: 0.0.55
       sourceRef:
         kind: HelmRepository
         name: toolhive

--- a/kubernetes/cluster-1/toolhive/operator.yaml
+++ b/kubernetes/cluster-1/toolhive/operator.yaml
@@ -10,6 +10,7 @@ spec:
   chart:
     spec:
       chart: toolhive-operator
+      version: 0.5.5
       sourceRef:
         kind: HelmRepository
         name: toolhive

--- a/kubernetes/cluster-1/toolhive/virtualserver.yaml
+++ b/kubernetes/cluster-1/toolhive/virtualserver.yaml
@@ -42,6 +42,8 @@ spec:
   config:
     operational:
       logLevel: debug
+    codeMode:
+      enabled: true
 ---
 apiVersion: toolhive.stacklok.dev/v1beta1
 kind: VirtualMCPServer
@@ -87,6 +89,8 @@ spec:
   config:
     operational:
       logLevel: debug
+    codeMode:
+      enabled: true
     aggregation:
       tools:
         - workload: calendar


### PR DESCRIPTION
## Summary
This change enables the `codeMode` feature across the toolhive VirtualServer configurations by adding the configuration flag to both the primary VirtualServer and VirtualMCPServer resources.

## Key Changes
- Added `codeMode.enabled: true` to the VirtualServer spec configuration
- Added `codeMode.enabled: true` to the VirtualMCPServer spec configuration
- Both configurations maintain existing `logLevel: debug` operational settings

## Implementation Details
The `codeMode` feature is enabled at the configuration level for both server types, allowing code-related functionality to be active in the cluster-1 environment. This change is applied consistently across both resource definitions to ensure uniform behavior.

https://claude.ai/code/session_01RgDt1YtK37fdjezm58ydQf