### PR TITLE
feat: add kubernetes mcp server

### DIFF
--- a/kubernetes/cluster-1/toolhive/servers/kubernetes.yaml
+++ b/kubernetes/cluster-1/toolhive/servers/kubernetes.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubernetes-mcp
+  namespace: toolhive-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-mcp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-mcp
+    namespace: toolhive-system
+---
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServer
+metadata:
+  name: kubernetes
+  namespace: toolhive-system
+spec:
+  groupRef:
+    name: toolhive
+  telemetryConfigRef:
+    name: toolhive
+  image: quay.io/containers/kubernetes_mcp_server:v0.0.65
+  serviceAccount: kubernetes-mcp


### PR DESCRIPTION
Deploys [containers/kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) as a ToolHive `MCPServer` in `toolhive-system`, following the existing patterns in `kubernetes/cluster-1/toolhive/servers/`.

- Image `quay.io/containers/kubernetes_mcp_server:v0.0.65` (latest release; image name per the project's Helm chart)
- Runs with default stdio transport and default toolsets (`core`, `config`, `helm`)
- Uses in-cluster auth via a dedicated `kubernetes-mcp` ServiceAccount (referenced through the CRD's `serviceAccount` field), bound to `cluster-admin` so all tools work on the main `toolhive` endpoint

Notes:
- The `toolhive-safe` VirtualMCPServer uses an explicit aggregation list, so this server is not exposed there. Read-only tools (e.g. `pods_list`, `pods_log`, `resources_get`) could be added to it in a follow-up if desired.
- If full cluster access is too broad, the binding can be switched to the built-in `view` ClusterRole plus the `--read-only` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLeCTZd7HWq5UYfdfYzJJx