### PR TITLE
chore: extend centralized renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
-    'config:recommended',
+    'github>pl4nty/.github',
     'docker:enableMajor',
     ':disableRateLimiting',
     ':dependencyDashboard',


### PR DESCRIPTION
Swaps `config:recommended` for the centralized preset `github>pl4nty/.github` (`config:best-practices` + `schedule:weekends` + 7-day `minimumReleaseAge` + OSV vulnerability alerts). All homelab-specific presets, managers, and automerge rules are kept.

Behaviour change to be aware of: this brings the central weekend schedule and 7-day `minimumReleaseAge`, which will slow the current update cadence (automerge still applies once PRs open; vulnerability fixes remain unscheduled with no release-age gate). `config:best-practices` also adds digest pinning beyond the existing `helpers:pinGitHubActionDigests`, so expect a round of pin PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsPuqPb9iXJfZUD9QiRkzC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsPuqPb9iXJfZUD9QiRkzC)_