### PR TITLE
chore(monitoring): drop custom dotnet auto-instrumentation image override

### DIFF
--- a/kubernetes/base/monitoring-system/opentelemetry-operator.yaml
+++ b/kubernetes/base/monitoring-system/opentelemetry-operator.yaml
@@ -41,10 +41,6 @@ spec:
       # https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md#0553-to-0560
       collectorImage:
         repository: otel/opentelemetry-collector-contrib
-      autoInstrumentationImage:
-        dotnet:
-          repository: ghcr.io/pl4nty/otel-operator-autoinstrumentation-dotnet
-          tag: latest@sha256:358512aab44a8900f0d3aaa8124372ad74ce3cea8b7b3543124dc11f1d073b23
       # disabled by default
       extraArgs:
         - --enable-go-instrumentation=true


### PR DESCRIPTION
Closing — premature.

The chart's default .NET auto-instrumentation image is not yet usable on this cluster's architecture in any released operator version. The enabling change is merged upstream on `main` but has not shipped in a tagged release, so removing the override now would fall back to an image that does not work on these nodes.

Superseded until an operator release including that change is available.