### PR TITLE
fix: restrict safe vMCP to its intended tool allowlist

### DIFF
--- a/kubernetes/cluster-1/toolhive/virtualserver.yaml
+++ b/kubernetes/cluster-1/toolhive/virtualserver.yaml
@@ -99,12 +99,6 @@ spec:
           excludeAll: true
         - workload: github
           excludeAll: true
-        - workload: grafana
-          excludeAll: true
-        - workload: kubernetes
-          excludeAll: true
-        - workload: obsidian
-          excludeAll: true
         - workload: calendar
           filter:
             - get_event_attachments
@@ -117,6 +111,93 @@ spec:
           filter:
             - list_contacts
             - get_contact
+        - workload: grafana
+          filter:
+            - analyze_loki_labels
+            - check_datasources_health
+            - find_error_pattern_logs
+            - find_slow_requests
+            - generate_deeplink
+            - get_alert_group
+            - get_annotation_tags
+            - get_annotations
+            - get_assertions
+            - get_current_oncall_users
+            - get_dashboard_by_uid
+            - get_dashboard_panel_queries
+            - get_dashboard_property
+            - get_dashboard_summary
+            - get_datasource
+            - get_incident
+            - get_oncall_shift
+            - get_panel_image
+            - get_plugin
+            - get_sift_analysis
+            - get_sift_investigation
+            - get_snapshot
+            - list_alert_groups
+            - list_datasources
+            - list_incidents
+            - list_loki_label_names
+            - list_loki_label_values
+            - list_oncall_schedules
+            - list_oncall_teams
+            - list_oncall_users
+            - list_prometheus_label_names
+            - list_prometheus_label_values
+            - list_prometheus_metric_metadata
+            - list_prometheus_metric_names
+            - list_provisioning_repositories
+            - list_pyroscope_label_names
+            - list_pyroscope_label_values
+            - list_pyroscope_profile_types
+            - list_sift_investigations
+            - list_snapshots
+            - query_loki_logs
+            - query_loki_patterns
+            - query_loki_stats
+            - query_prometheus
+            - query_prometheus_histogram
+            - query_pyroscope
+            - search_dashboards
+            - search_folders
+            - search_plugin_information
+            - suggest_loki_alloy_label_config
+            - tempo_docs-config
+            - tempo_docs-traceql
+            - tempo_get-attribute-names
+            - tempo_get-attribute-values
+            - tempo_get-trace
+            - tempo_traceql-metrics-instant
+            - tempo_traceql-metrics-range
+            - tempo_traceql-search
+            - validate_provisioning_file
+        - workload: kubernetes
+          filter:
+            - configuration_view
+            - events_list
+            - namespaces_list
+            - nodes_log
+            - nodes_stats_summary
+            - nodes_top
+            - pods_get
+            - pods_list
+            - pods_list_in_namespace
+            - pods_log
+            - pods_top
+            - projects_list
+            - resources_get
+            - resources_list
+        - workload: obsidian
+          filter:
+            - get_frontmatter
+            - get_notes_info
+            - get_vault_stats
+            - list_all_tags
+            - list_directory
+            - read_multiple_notes
+            - read_note
+            - search_notes
         - workload: onedrive
           filter:
             - get_drive

--- a/kubernetes/cluster-1/toolhive/virtualserver.yaml
+++ b/kubernetes/cluster-1/toolhive/virtualserver.yaml
@@ -90,7 +90,21 @@ spec:
     operational:
       logLevel: debug
     aggregation:
+      # vMCP advertises every tool from any workload in the group that isn't
+      # listed below, so unsafe workloads need an explicit excludeAll.
       tools:
+        - workload: amazon-scraper
+          excludeAll: true
+        - workload: daytona
+          excludeAll: true
+        - workload: github
+          excludeAll: true
+        - workload: grafana
+          excludeAll: true
+        - workload: kubernetes
+          excludeAll: true
+        - workload: obsidian
+          excludeAll: true
         - workload: calendar
           filter:
             - get_event_attachments


### PR DESCRIPTION
## Problem

The `toolhive-safe` VirtualMCPServer was advertising `daytona_*`, `amazon-scraper_*`, `github_*`, `grafana_*`, `kubernetes_*` and `obsidian_*` tools despite them not being in the allowlist — including `daytona_execute_command`, `kubernetes_pods_exec` and `amazon-scraper_perform-purchase`.

## Cause

`spec.config.aggregation.tools` is not a workload allowlist — it's per-workload configuration. From the aggregator ([`shouldAdvertiseTool`](https://github.com/stacklok/toolhive/blob/v0.40.0/pkg/vmcp/aggregator/default_aggregator.go)):

```go
wlConfig, exists := a.toolConfigMap[backendID]
if !exists {
    // No config for this backend, advertise the tool
    return true
}
```

The map is keyed by `tools[].workload`, so any workload in the `toolhive` MCPGroup without an entry is advertised in full. The safe server listed 7 of the group's 13 workloads, so the other 6 passed through unfiltered.

The global `aggregation.excludeAllTools: true` is not usable as a default-deny here — it short-circuits before the per-workload `filter` check, so it would hide the allowlisted tools too.

## Fix

Every workload in the group now has an explicit entry:

- `excludeAll: true` for `amazon-scraper`, `daytona`, `github`
- read-only allowlists for `grafana` (59 tools), `kubernetes` (14) and `obsidian` (8)

Mutating tools stay hidden — `kubernetes` pod exec/run/delete and all `resources_*` writes, `obsidian` note and tag writes, `grafana` create/update/delete plus `grafana_api_request` (proxies arbitrary Grafana API calls, so not read-only despite the name).

Verified every `MCPServer`/`MCPRemoteProxy` joining the group has an entry, and that no entry names a workload that doesn't exist.

## Notes

- `kubernetes_resources_get`, `kubernetes_resources_list` and `kubernetes_configuration_view` are read-only but can read Secrets and cluster config. They're in the allowlist as requested; worth a second look if the safe endpoint is reachable by unsupervised agents.
- Excluded tools are hidden from `tools/list` but remain in vMCP's internal routing table for composite tools. Clients can't discover or call them directly.
- This is still default-allow upstream: adding a new server to the group exposes it here until it gets an entry.