### PR TITLE
feat: mirror flat-viewer

### DIFF
--- a/kubernetes/oke/flat-viewer.yaml
+++ b/kubernetes/oke/flat-viewer.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/app-template-4.6.2/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: flat-viewer
+  namespace: default
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    global:
+      createDefaultServiceAccount: false
+    controllers:
+      main:
+        strategy: RollingUpdate
+        rollingUpdate:
+          unavailable: 0
+        containers:
+          main:
+            image:
+              repository: ghcr.io/pl4nty/flat-viewer
+              tag: latest
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 8080
+    route:
+      main:
+        parentRefs:
+          - namespace: default
+            name: ${CLUSTER_NAME}
+        hostnames:
+          - flat.${PUBLIC_DOMAIN}
+        rules:
+          - backendRefs:
+              - name: flat-viewer
+                port: 8080

--- a/kubernetes/oke/flat-viewer.yaml
+++ b/kubernetes/oke/flat-viewer.yaml
@@ -57,7 +57,7 @@ spec:
           - namespace: default
             name: ${CLUSTER_NAME}
         hostnames:
-          - flat.${PUBLIC_DOMAIN}
+          - flatgithub.${PUBLIC_DOMAIN}
         rules:
           - backendRefs:
               - name: flat-viewer

--- a/kubernetes/oke/flat-viewer.yaml
+++ b/kubernetes/oke/flat-viewer.yaml
@@ -37,7 +37,7 @@ spec:
           main:
             image:
               repository: ghcr.io/pl4nty/flat-viewer
-              tag: latest
+              tag: latest@sha256:05b26cdb371330a8a5f075ee6aacc2a788cc1da05052dcea9821c020dda91ee3
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
[githubocto/flat-viewer](https://github.com/githubocto/flat-viewer) was archived on 2026-08-06, taking the hosted flatgithub.com with it eventually. This deploys our own copy at `flat.${PUBLIC_DOMAIN}`.

The image comes from [pl4nty/containers#2366](https://github.com/pl4nty/containers/pull/2366) (merged) — submodule pinned at upstream's final commit, node 16 build stage (Vite 2 needs the `"./": "./"` PostCSS exports mapping Node removed in 17), served by static-web-server on 8080 with a fallback page so the viewer's `/:owner/:name` client-side routes resolve on a cold load.

## Testing

Built the bundle the same way the Dockerfile does (node 16, `yarn install --frozen-lockfile && yarn build`), served `dist` behind an equivalent fallback, and drove it in Chromium against `pl4nty/data`:

- `/pl4nty/data` resolved through the fallback, listed the repo's data files and its commit history from the GitHub API.
- `archive/cert-oids.csv` rendered all 136 rows in the Flat grid, with column filters and the CSV/JSON download buttons working.
- `microsoft_azure_endpoints.json` rendered in the scalar detail view — that file is an object of strings, not a table, so it's upstream's expected behaviour rather than a mirror bug.

Pulled the published image back from ghcr to check it matches: the index covers `linux/amd64` and `linux/arm64`, the config carries `SERVER_FALLBACK_PAGE=/public/index.html` and `SERVER_PORT=8080`, and the final layer's `assets/*` hashes are identical to the local build above — so CI shipped the same bundle that was tested.

Not verified: static-web-server actually answering a request. No container runtime was available in the session, so the deploy is the first time that runs.

Unauthenticated api.github.com is 60 requests/hour per IP; the viewer's own PAT box (stored in localStorage) is the upstream workaround if that becomes annoying.