### PR TITLE
feat(toolhive): deny-by-default tool visibility for safe vMCP

### DIFF
--- a/kubernetes/cluster-1/toolhive/crds.yaml
+++ b/kubernetes/cluster-1/toolhive/crds.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: toolhive-operator-crds
-      version: 0.40.0
+      version: 0.42.1
       sourceRef:
         kind: HelmRepository
         name: toolhive

--- a/kubernetes/cluster-1/toolhive/operator.yaml
+++ b/kubernetes/cluster-1/toolhive/operator.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: toolhive-operator
-      version: 0.40.0
+      version: 0.42.1
       sourceRef:
         kind: HelmRepository
         name: toolhive

--- a/kubernetes/cluster-1/toolhive/virtualserver.yaml
+++ b/kubernetes/cluster-1/toolhive/virtualserver.yaml
@@ -90,15 +90,11 @@ spec:
     operational:
       logLevel: debug
     aggregation:
-      # vMCP advertises every tool from any workload in the group that isn't
-      # listed below, so unsafe workloads need an explicit excludeAll.
+      # defaultToolVisibility: deny means any workload in the group with no
+      # entry below contributes no tools, so unsafe workloads just stay
+      # unlisted instead of needing an explicit excludeAll.
+      defaultToolVisibility: deny
       tools:
-        - workload: amazon-scraper
-          excludeAll: true
-        - workload: daytona
-          excludeAll: true
-        - workload: github
-          excludeAll: true
         - workload: calendar
           filter:
             - get_event_attachments


### PR DESCRIPTION
## Summary

- Bumps `toolhive-operator` and `toolhive-operator-crds` Helm charts from 0.40.0 to **0.42.1**, the first published release containing `spec.config.aggregation.defaultToolVisibility` ([stacklok/toolhive#6163](https://github.com/stacklok/toolhive/pull/6163), closes [stacklok/toolhive#6073](https://github.com/stacklok/toolhive/issues/6073)).
- Sets `defaultToolVisibility: deny` on the `toolhive-safe` `VirtualMCPServer` so unlisted backends contribute no tools, and removes the now-redundant `excludeAll: true` entries for `amazon-scraper`, `daytona`, and `github` — staying unlisted achieves the same result under deny mode.
- The unrestricted `toolhive` `VirtualMCPServer` is left untouched.
- Bare workload entries (`selfhost`, `google-maps`, `youtube-transcript`) are kept as-is: per the CRD field description, a backend that has *any* entry in `tools` still opts in and is unaffected by `defaultToolVisibility` (`ExcludeAll`/`Filter` on that entry decide the rest), so removing them would have changed today's exposure. Keeping them preserves current behaviour exactly.
- Replaces the stale comment above `aggregation.tools` describing the old allow-by-default model with one describing deny-by-default.

Chart contents were verified directly by pulling the `toolhive-operator-crds` 0.42.1 OCI artifact from `ghcr.io` and inspecting the generated CRD YAML for the field description, rather than assuming from version numbers.

## Test plan

- [x] Confirmed `defaultToolVisibility` is present in the `toolhive-operator-crds` 0.42.1 chart's CRD manifest (absent in 0.42.0).
- [x] Verified field semantics against the CRD description text before editing (deny only affects backends with **no** entry in `tools`; listed entries, including bare ones, are unaffected).
- [x] `python3 -c "yaml.safe_load_all(...)"` confirms `crds.yaml`, `operator.yaml`, and `virtualserver.yaml` all parse as valid YAML (the `${PUBLIC_DOMAIN}` Flux substitution vars parse fine as plain scalars).
- [x] Confirmed resulting tool exposure for `toolhive-safe` is unchanged: previously-excluded workloads stay excluded (now via omission instead of `excludeAll: true`), and previously-exposed workloads (bare + filtered entries) are untouched.
- [ ] CI


---
_Generated by [Claude Code](https://claude.ai/code/session_01GkwJmdG2nPLdgcWUgeGZ63)_